### PR TITLE
MCP1.0 full implementation

### DIFF
--- a/include/mcp/syscalls.h
+++ b/include/mcp/syscalls.h
@@ -772,7 +772,7 @@ extern unsigned short sys_kbd_scancode();
  * - ALT: Used when only ALT is presse
  * - ALT-SHIFT: Used when ALT is pressed and either CAPSLOCK is down
  *   or SHIFT is pressed (but not both)
- *
+ * 
  * Inputs:
  * tables = pointer to the keyboard translation tables
  */

--- a/include/mcp/syscalls.h
+++ b/include/mcp/syscalls.h
@@ -872,8 +872,8 @@ void sys_txt_set_border( short screen, short width, short height );
  * Returns:
  *  nothing
  */
-void sys_txt_set_border_color( short screen, unsigned byte red,
-                                unsigned byte green, unsigned byte blue );
+void sys_txt_set_border_color( short screen, uint8_t red,
+                                uint8_t green, uint8_t blue );
 
 /*
  * Set the font to be used in text mode for the screen
@@ -887,8 +887,8 @@ void sys_txt_set_border_color( short screen, unsigned byte red,
  * Returns:
  *  0 on success, any other number means error (invalid screen, invalid font size)
  */
-short sys_txt_set_font( short screen, short width, short heigth, 
-                                unisgend char *data );
+short sys_txt_set_font( short screen, short width, short height, 
+                                unsigned char *data );
 
 /*
  * Set the appearance of the text mode cursor

--- a/include/mcp/syscalls.h
+++ b/include/mcp/syscalls.h
@@ -786,7 +786,7 @@ extern const char * sys_err_message(short err_number);
 
 /**
  * Text Display calls
- /**
+ **/
 
 /*
  * Reset a screen to its default text mode

--- a/include/mcp/syscalls.h
+++ b/include/mcp/syscalls.h
@@ -87,7 +87,6 @@
 #define KFN_VAR_SET             0x44    /* Set value of a system variable */
 #define KFN_VAR_GET             0x45    /* Return the value of a system variable */
 
-
 /* System: Misc calls */
 
 #define KFN_TIME_JIFFIES        0x50    /* Gets the current time code (increments since boot) */
@@ -96,6 +95,27 @@
 #define KFN_KBD_SCANCODE        0x53    /* Get the next scan code from the keyboard */
 #define KFN_KBD_LAYOUT          0x54    /* Set the translation tables for the keyboard */
 #define KFN_ERR_MESSAGE         0x55    /* Return an error description, given an error number */
+
+/* Text Display calls */
+#define KFN_TXT_INIT_SCREEN     0x60    /* Reset a screen to its default text mode */
+#define KFN_TXT_GET_CAPS        0x61    /* Return a description of a screen's capabilities */
+#define KFN_TXT_SET_MODE        0x62    /* Set the display mode of a screen */
+#define KFN_TXT_SETSIZES        0x63    /* Calculate the size of the text matrix */
+#define KFN_TXT_SET_RESOLUTION  0x64    /* Set the base display resolution */
+#define KFN_TXT_SET_BORDER      0x65    /* Set the border size */
+#define KFN_TXT_SET_BORDER_COLOR    0x66    /* Set border color */
+#define KFN_TXT_SET_FONT        0x67    /* Set text mode font for the display */
+#define KFN_TXT_SET_CURSOR      0x68    /* Set cursor appearance for the display */
+#define KFN_TXT_SET_REGION      0x69    /* Set clipping/scrolling region for display */
+#define KFN_TXT_GET_REGION      0x6A    /* Get current clipping/scrolling region */
+#define KFN_TXT_SET_COLOR       0x6B    /* Set foreground and background colors for text */
+#define KFN_TXT_GET_COLOR       0x6C    /* Get current foreground and background colors */
+#define KFN_TXT_SET_XY          0x6D    /* Set cursor position within current region */
+#define KFN_TXT_GET_XY          0x6E    /* Get cursor position within current region */
+#define KFN_TXT_SCROLL          0x6F    /* Scroll current region */
+#define KFN_TXT_SET_CURSOR_VIS  0x71    /* Set cursor visibility */
+#define KFN_TXT_GET_SIZES       0x72    /* Gets screensize in pixels and characters */
+
 
 /*
  * Call into the kernel (provided by assembly)
@@ -762,6 +782,231 @@ extern short sys_kbd_setlayout(const char * tables);
  * Return an error message given an error number
  */
 extern const char * sys_err_message(short err_number);
+
+
+/**
+ * Text Display calls
+ /**
+
+/*
+ * Reset a screen to its default text mode
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *
+ * Returns:
+ *  nothing
+ */
+extern void sys_txt_init_screen( short screen );
+
+/*
+ * Return a description of a screen's capabilities
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *
+ * Returns:
+ *  pointer to txt_capabilities structure (p_txt_capabilities)
+ */
+const p_txt_capabilities sys_txt_get_caps( short screen );
+
+/*
+ * Set the display mode of a screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  mode = desired mode (one from TXT_MODE_TEXT, TXT_MODE_BITMAP, TXT_MODE_TILE, 
+ *                          TXT_MODE_SPRITE, TXT_MODE_SLEEP)
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_mode( short screen, short mode );
+
+/*
+ * Set text screen device driver to current screen geometry (resolution, border size)
+ *
+ * Inputs:
+ *  none
+ *
+ * Returns:
+ *  0 on succcess or any other number on error
+ */
+void sys_txt_setsizes();
+
+/*
+ * Set the base display resolution of the screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  horizontal = number of horizontal pixels
+ *  vertical = number of verticl pixels
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_resolution( short screen, short horizontal, short vertical );
+
+/*
+ * Set the size of the border (around the screen)
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  width = border width left and right of the screen in pixels
+ *  height = border height top and bottom of the screen in pixels
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_border( short screen, short width, short height );
+
+/*
+ * Set the color of the border (around the screen) with RGB components
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  red = red component of color (0-255)
+ *  green = green component of color (0-255)
+ *  blue = blue component of border (0-255)
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_border_color( short screen, unsigned byte red,
+                                unsigned byte green, unsigned byte blue );
+
+/*
+ * Set the font to be used in text mode for the screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  width = width of the characters in pixels
+ *  height = height of the characters in pixels
+ *  data = pointer to font data
+ *
+ * Returns:
+ *  0 on success, any other number means error (invalid screen, invalid font size)
+ */
+short sys_txt_set_font( short screen, short width, short heigth, 
+                                unisgend char *data );
+
+/*
+ * Set the appearance of the text mode cursor
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  enable = hide(0) or show (any other number) cursor
+ *  rate = blink rate of the cursor (in Hz, see MCP manual for ranges)
+ *  character = ASCII code of the glyph from the screen's font as the cursor
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_cursor( short screen, short enable, short rate, char character );
+
+/*
+ * Set the rectangular region of the screen that will be used for printing,
+ * scrolling and filling.
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  region = pointer to t_rect structure (upper left corner, width, height)
+ *              coordinates in character cells. (0,0) is upper-left,
+ *              size 0 means fullscreen
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_region( short screen, p_rect region );
+
+/*
+ * Set the foreground and background color for subsequent printing to the screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  foreground = color index for foreground color (0-15)
+ *  background = color index for background color (0-15)
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_color( short screen, short foreground, short background );
+
+/*
+ * Get the current foreground and background color
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  foreground = pointer to retrieve color index for foreground color (0-15)
+ *  background = pointer to retrieve color index for background color (0-15)
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+ short sys_txt_get_color( short screen, short *foreground, short *background );
+
+ /*
+ * Set cursor position on the screen, relative to origin of current region
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  x = relative x position (in character positions)
+ *  y = relative y position (in character positions)
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_xy( short screen, short x, short y );
+
+/*
+ * Get cursor position on the screen, relative to origin of current region
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  position = pointer to x,y structure to retrive position
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_get_xy( short screen, p_point position );
+
+/*
+ * Scroll the text in the current region
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  horizontal = number of horizontal pixels to scroll
+ *  vertical = number of verticl pixels to scroll
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_scroll( short screen, short horizontal, short vertical );
+
+/*
+ * Set visibility of the cursor
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  is_visible = hidden (FALSE or 0) or visible (any other number)
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_cursor_vis( short screen, short is_visible );
+
+/*
+ * SGet screensize in total pixels (so without taking the border into consideration)
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  text_size = pointer to t_extent structure to retrieve size in visible characters
+ *  pixel_size = pointer to t_extent structure to retrieve size in pixels
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_get_sizes( short screen, p_extent text_size, p_extent pixel_size );
 
 
 #endif

--- a/include/mcp/types.h
+++ b/include/mcp/types.h
@@ -241,4 +241,54 @@ typedef struct {
     int32_t arg6;
 } t_syscall_params, *p_syscall_params;
 
+/*=========================================
+ * Screen information
+ *========================================*/
+
+/*
+ * Structure to specify the size of a rectangle
+ */
+typedef struct s_extent {
+    short width;        /**< The width of the region */
+    short height;       /**< The height of the region */
+} t_extent, *p_extent;
+
+/*
+ * Structure to specify the location of a point on the screen
+ */
+ C256 FMX C256 U C256 GenX C256 U+ A2560 U+ A2560 X A2560 U A2560 K
+    typedef struct s_point {
+    short x;
+    short y;
+} t_point, *p_point;
+
+/**< The column of the point */
+/**< The row of the point */
+/*
+ * Structure to specify a rectangular area on the screen
+ */
+typedef struct s_rect {
+    t_point origin;         /**< The upper-left corner of the rectangle */
+    t_extent size;          /**< The size of the rectangle */
+} t_rect, *p_rect;
+
+/*
+* Structure to specify the capabilities of a screen’s text driver
+*/
+typedef struct s_txt_capabilities {
+short number;
+short supported_modes;
+short font_size_count;
+p_extent font_sizes;
+/**< The unique ID of the screen */
+/**< The display modes supported on this screen */
+/**< The number of supported font sizes */
+/**< Pointer to a list of t_extent listing all
+supported font sizes (in pixels) */
+    short resolution_count;     /**< The number of supported display resolutions */
+    p_extent resolutions;       /**< Pointer to a list of t_extent listing all
+supported display resolutions (in pixels) */
+} t_txt_capabilities, *p_txt_capabilities;
+
+
 #endif

--- a/include/mcp/types.h
+++ b/include/mcp/types.h
@@ -256,8 +256,7 @@ typedef struct s_extent {
 /*
  * Structure to specify the location of a point on the screen
  */
- C256 FMX C256 U C256 GenX C256 U+ A2560 U+ A2560 X A2560 U A2560 K
-    typedef struct s_point {
+typedef struct s_point {
     short x;
     short y;
 } t_point, *p_point;

--- a/src/mcp_syscalls.c
+++ b/src/mcp_syscalls.c
@@ -712,7 +712,7 @@ unsigned long sys_mem_reserve( unsigned long size ) {
  */
 void sys_proc_elevate() {
     t_syscall_params params = {0};
-    return syscall(KFN_PROC_ELEVATE, &params);   
+    syscall(KFN_PROC_ELEVATE, &params);   
 }
 
 /*
@@ -742,7 +742,7 @@ extern short sys_var_set( const char *name, const char *value ) {
  */
 const char *sys_var_get( const char *name ) {
     t_syscall_params params = {.arg1 = (uint32_t)name};
-    return syscall(KFN_VAR_GET, &params);    
+    return (const char *)syscall(KFN_VAR_GET, &params);    
 }
 
 /*

--- a/src/mcp_syscalls.c
+++ b/src/mcp_syscalls.c
@@ -726,7 +726,7 @@ void sys_proc_elevate() {
  *  0 on success, any other number on error
  */
 extern short sys_var_set( const char *name, const char *value ) {
-    t_syscall_params params = {.arg1 = (uint32_t)name, .arg2= (uint_32t)value};
+    t_syscall_params params = {.arg1 = (uint32_t)name, .arg2= (uint32_t)value};
     return syscall(KFN_VAR_SET, &params);      
 }
 

--- a/src/mcp_syscalls.c
+++ b/src/mcp_syscalls.c
@@ -16,6 +16,42 @@ void sys_exit(short result) {
 }
 
 /*
+ * Register a handler for a given interrupt.
+ *
+ * Inputs:
+ * n = the number of the interrupt
+ * handler = pointer to the interrupt handler to register
+ *
+ * Returns:
+ * the pointer to the previous interrupt handler
+ */
+p_int_handler sys_int_register(unsigned short n, p_int_handler handler) {
+    t_syscall_params params = {.arg1 = n, .arg2 = (int32_t) handler};
+    return (p_int_handler) syscall(KFN_INT_REGISTER, &params);
+}
+
+/*
+ * Enable an interrupt
+ *
+ * Inputs:
+ * n = the number of the interrupt
+ */
+void sys_int_enable(unsigned short n) {
+    t_syscall_params params = {.arg1 = n};
+    syscall(KFN_INT_ENABLE, &params);
+}
+
+/*
+ * Disable an interrupt by masking it
+ *
+ * Inputs:
+ * n = the number of the interrupt: n[7..4] = group number, n[3..0] = individual number.
+ */
+void sys_int_disable(unsigned short n) {
+    t_syscall_params params = {.arg1 = n};
+    syscall(KFN_INT_DISABLE, &params);
+}
+/*
  * Enable all interrupts
  *
  * NOTE: this is actually provided in the low level assembly
@@ -36,51 +72,14 @@ void sys_int_disable_all() {
 }
 
 /*
- * Disable an interrupt by masking it
+ * Acknowledge an interrupt (clear out its pending flag)
  *
  * Inputs:
  * n = the number of the interrupt: n[7..4] = group number, n[3..0] = individual number.
  */
-void sys_int_disable(unsigned short n) {
+void sys_int_clear(unsigned short n) {
     t_syscall_params params = {.arg1 = n};
-    syscall(KFN_INT_DISABLE, &params);
-}
-
-/*
- * Enable an interrupt
- *
- * Inputs:
- * n = the number of the interrupt
- */
-void sys_int_enable(unsigned short n) {
-    t_syscall_params params = {.arg1 = n};
-    syscall(KFN_INT_ENABLE, &params);
-}
-
-/*
- * Fill out a s_sys_info structure with the information about the current system
- *
- * Inputs:
- * info = pointer to a s_sys_info structure to fill out
- */
-void sys_get_info(p_sys_info info) {
-    t_syscall_params params = {.arg1 = (int32_t) info};
-    syscall(KFN_SYS_GET_INFO, &params);
-}
-
-/*
- * Register a handler for a given interrupt.
- *
- * Inputs:
- * n = the number of the interrupt
- * handler = pointer to the interrupt handler to register
- *
- * Returns:
- * the pointer to the previous interrupt handler
- */
-p_int_handler sys_int_register(unsigned short n, p_int_handler handler) {
-    t_syscall_params params = {.arg1 = n, .arg2 = (int32_t) handler};
-    return (p_int_handler) syscall(KFN_INT_REGISTER, &params);
+    syscall(KFN_INT_CLEAR, &params);
 }
 
 /*
@@ -96,35 +95,20 @@ short sys_int_pending(unsigned short n) {
     t_syscall_params params = {.arg1 = n};
     return syscall(KFN_INT_PENDING, &params);
 }
-
 /*
- * Acknowledge an interrupt (clear out its pending flag)
+ * Fill out a s_sys_info structure with the information about the current system
  *
  * Inputs:
- * n = the number of the interrupt: n[7..4] = group number, n[3..0] = individual number.
+ * info = pointer to a s_sys_info structure to fill out
  */
-void sys_int_clear(unsigned short n) {
-    t_syscall_params params = {.arg1 = n};
-    syscall(KFN_INT_CLEAR, &params);
+void sys_get_info(p_sys_info info) {
+    t_syscall_params params = {.arg1 = (int32_t) info};
+    syscall(KFN_SYS_GET_INFO, &params);
 }
 
 /***
  *** Channel system calls
  ***/
-
-/*
- * Read a single byte from the channel
- *
- * Inputs:
- *  channel = the number of the channel
- *
- * Returns:
- *  the value read (if negative, error)
- */
-short sys_chan_read_b(short channel) {
-    t_syscall_params params = {.arg1 = channel};
-    return syscall(KFN_CHAN_READ_B, &params);
-}
 
 /*
  * Read bytes from the channel
@@ -143,6 +127,19 @@ short sys_chan_read(short channel, unsigned char * buffer, short size) {
 }
 
 /*
+ * Read a single byte from the channel
+ *
+ * Inputs:
+ *  channel = the number of the channel
+ *
+ * Returns:
+ *  the value read (if negative, error)
+ */
+short sys_chan_read_b(short channel) {
+    t_syscall_params params = {.arg1 = channel};
+    return syscall(KFN_CHAN_READ_B, &params);
+}
+/*
  * Read a line of text from the channel
  *
  * Inputs:
@@ -156,22 +153,6 @@ short sys_chan_read(short channel, unsigned char * buffer, short size) {
 short sys_chan_readline(short channel, unsigned char * buffer, short size) {
     t_syscall_params params = {.arg1 = channel, .arg2 = (int32_t) buffer, .arg3 = size};
     return syscall(KFN_CHAN_READ_LINE, &params);
-}
-
-
-/*
- * Write a single byte to the device
- *
- * Inputs:
- *  channel = the number of the channel
- *  b = the byte to write
- *
- * Returns:
- *  0 on success, a negative value on error
- */
-short sys_chan_write_b(short channel, unsigned char b) {
-    t_syscall_params params = {.arg1 = channel, .arg2 = b};
-    return syscall(KFN_CHAN_WRITE_B, &params);
 }
 
 /*
@@ -190,17 +171,18 @@ short sys_chan_write(short channel, unsigned char * buffer, short size) {
 }
 
 /*
- * Return the status of the channel device
+ * Write a single byte to the device
  *
  * Inputs:
  *  channel = the number of the channel
+ *  b = the byte to write
  *
  * Returns:
- *  the status of the device
+ *  0 on success, a negative value on error
  */
-short sys_chan_status(short channel) {
-    t_syscall_params params = {.arg1 = channel};
-    return syscall(KFN_CHAN_STATUS, &params);
+short sys_chan_write_b(short channel, unsigned char b) {
+    t_syscall_params params = {.arg1 = channel, .arg2 = b};
+    return syscall(KFN_CHAN_WRITE_B, &params);
 }
 
 /*
@@ -234,6 +216,20 @@ short sys_chan_seek(short channel, long position, short base) {
 }
 
 /*
+ * Return the status of the channel device
+ *
+ * Inputs:
+ *  channel = the number of the channel
+ *
+ * Returns:
+ *  the status of the device
+ */
+short sys_chan_status(short channel) {
+    t_syscall_params params = {.arg1 = channel};
+    return syscall(KFN_CHAN_STATUS, &params);
+}
+
+/*
  * Issue a control command to the device
  *
  * Inputs:
@@ -248,6 +244,20 @@ short sys_chan_seek(short channel, long position, short base) {
 short sys_chan_ioctrl(short channel, short command, uint8_t * buffer, short size) {
     t_syscall_params params = {.arg1 = channel, .arg2 = command, .arg3 = (int32_t) buffer, .arg4 = size};
     return syscall(KFN_CHAN_IOCTRL, &params);
+}
+
+/* 
+ * Register a channel device driver (NOT TESTED) <>
+ *
+ * Inputs:
+ *  device = pointer to the device, including handler functions
+ *
+ * Returns:
+ *  <>
+ */
+short sys_chan_register(struct s_dev_chan *device) {
+    t_syscall_params params = {.arg1 = (int32_t)device};
+    return syscall(KFN_CHAN_REGISTER, &params);
 }
 
 /*
@@ -280,17 +290,36 @@ short sys_chan_close(short chan) {
     return syscall(KFN_CHAN_CLOSE, &params);
 }
 
+/* Swap two channels (given their IDS)
+ *
+ * Inputs:
+ *  channel1, channel2 = channel IDs to be swapped
+ *
+ * Returns:
+ *  0 on success, any other on error
+ */
+short sys_chan_swap(short channel1, short channel2) (
+    t_syscall_params params = {.arg1 = channel1, .arg2 = channel2};
+    return syscall(KFN_CHAN_SWAP, &params);
+)
+
+/* Get the device ID of the device on  a channel
+ *
+ * Inputs:
+ *  channel = channel of the device
+ *
+ * Returns:
+ *  device ID of the device on the channel
+ */
+short sys_chan_device(short channel) {
+    t_syscall_params params = {.arg1 = channel};
+    return syscall(KFN_CHAN_DEVICE, &params);
+}
+
+
 /***
  *** Block device system calls
  ***/
-
-//
-// Register a block device driver
-//
-short sys_bdev_register(p_dev_block device) {
-    t_syscall_params params = {.arg1 = (int32_t) device};
-    return syscall(KFN_BDEV_REGISTER, &params);
-}
 
 //
 // Read a block from the device
@@ -304,7 +333,7 @@ short sys_bdev_register(p_dev_block device) {
 // Returns:
 //  number of bytes read, any negative number is an error code
 //
-short sys_bdev_read(short dev, long lba, unsigned char * buffer, short size) {
+short sys_bdev_getblock(short dev, long lba, unsigned char * buffer, short size) {
     t_syscall_params params = {.arg1 = dev, .arg2 = lba, .arg3 = (int32_t) buffer, .arg4 = size};
     return syscall(KFN_BDEV_GETBLOCK, &params);
 }
@@ -321,23 +350,9 @@ short sys_bdev_read(short dev, long lba, unsigned char * buffer, short size) {
 // Returns:
 //  number of bytes written, any negative number is an error code
 //
-short sys_bdev_write(short dev, long lba, const unsigned char * buffer, short size) {
+short sys_bdev_putblock(short dev, long lba, const unsigned char * buffer, short size) {
     t_syscall_params params = {.arg1 = dev, .arg2 = lba, .arg3 = (int32_t) buffer, .arg4 = size};
     return syscall(KFN_BDEV_PUTBLOCK, &params);
-}
-
-//
-// Return the status of the block device
-//
-// Inputs:
-//  dev = the number of the device
-//
-// Returns:
-//  the status of the device
-//
-short sys_bdev_status(short dev) {
-    t_syscall_params params = {.arg1 = dev};
-    return syscall(KFN_BDEV_STATUS, &params);
 }
 
 //
@@ -355,6 +370,21 @@ short sys_bdev_flush(short dev) {
 }
 
 //
+// Return the status of the block device
+//
+// Inputs:
+//  dev = the number of the device
+//
+// Returns:
+//  the status of the device
+//
+short sys_bdev_status(short dev) {
+    t_syscall_params params = {.arg1 = dev};
+    return syscall(KFN_BDEV_STATUS, &params);
+}
+
+
+//
 // Issue a control command to the device
 //
 // Inputs:
@@ -370,6 +400,15 @@ short sys_bdev_ioctrl(short dev, short command, unsigned char * buffer, short si
     t_syscall_params params = {.arg1 = dev, .arg2 = command, .arg3 = (int32_t) buffer, .arg4 = size};
     return syscall(KFN_BDEV_IOCTRL, &params);
 }
+
+//
+// Register a block device driver
+//
+short sys_bdev_register(p_dev_block device) {
+    t_syscall_params params = {.arg1 = (int32_t) device};
+    return syscall(KFN_BDEV_REGISTER, &params);
+}
+
 
 /*
  * File System Calls
@@ -478,44 +517,6 @@ short sys_fsys_findnext(short dir, p_file_info file) {
     return syscall(KFN_FINDNEXT, &params);
 }
 
-/*
- * Get the label for the drive holding the path
- *
- * Inputs:
- * path = path to the drive
- * label = buffer that will hold the label... should be at least 35 bytes
- */
-short sys_fsys_get_label(const char * path, char * label) {
-    t_syscall_params params = {.arg1 = (int32_t) path, .arg2 = (int32_t) label};
-    return syscall(KFN_GET_LABEL, &params);
-}
-
-/*
- * Set the label for the drive holding the path
- *
- * Inputs:
- * drive = drive number
- * label = buffer that holds the label
- */
-short sys_fsys_set_label(short drive, const char * label) {
-    t_syscall_params params = {.arg1 = drive, .arg2 = (int32_t) label};
-    return syscall(KFN_SET_LABEL, &params);
-}
-
-/**
- * Create a directory
- *
- * Inputs:
- * path = the path of the directory to create.
- *
- * Returns:
- * 0 on success, negative number on failure.
- */
-short sys_fsys_mkdir(const char * path) {
-    t_syscall_params params = {.arg1 = (int32_t) path};
-    return syscall(KFN_MKDIR, &params);
-}
-
 /**
  * Delete a file or directory
  *
@@ -543,6 +544,65 @@ short sys_fsys_delete(const char * path) {
 short sys_fsys_rename(const char * old_path, const char * new_path) {
     t_syscall_params params = {.arg1 = (int32_t) old_path, .arg2 = (int32_t) new_path};
     return syscall(KFN_RENAME, &params);
+}
+
+/**
+ * Create a directory
+ *
+ * Inputs:
+ * path = the path of the directory to create.
+ *
+ * Returns:
+ * 0 on success, negative number on failure.
+ */
+short sys_fsys_mkdir(const char * path) {
+    t_syscall_params params = {.arg1 = (int32_t) path};
+    return syscall(KFN_MKDIR, &params);
+}
+
+/*
+ * Load a file into memory at the designated destination address.
+ *
+ * If destination = 0, the file must be in a recognized binary format
+ * that specifies its own loading address.
+ *
+ * Inputs:
+ * path = the path to the file to load
+ * destination = the destination address (0 for use file's address)
+ * start = pointer to the long variable to fill with the starting address
+ *         (0 if not an executable, any other number if file is executable
+ *         with a known starting address)
+ *
+ * Returns:
+ * 0 on success, negative number on error
+ */
+short sys_fsys_load(const char * path, long destination, long * start) {
+    t_syscall_params params = {.arg1 = (int32_t) path, .arg2 = destination, .arg3 = (int32_t) start};
+    return syscall(KFN_LOAD, &params);
+}
+
+/*
+ * Get the label for the drive holding the path
+ *
+ * Inputs:
+ * path = path to the drive
+ * label = buffer that will hold the label... should be at least 35 bytes
+ */
+short sys_fsys_get_label(const char * path, char * label) {
+    t_syscall_params params = {.arg1 = (int32_t) path, .arg2 = (int32_t) label};
+    return syscall(KFN_GET_LABEL, &params);
+}
+
+/*
+ * Set the label for the drive holding the path
+ *
+ * Inputs:
+ * drive = drive number
+ * label = buffer that holds the label
+ */
+short sys_fsys_set_label(short drive, const char * label) {
+    t_syscall_params params = {.arg1 = drive, .arg2 = (int32_t) label};
+    return syscall(KFN_SET_LABEL, &params);
 }
 
 /**
@@ -575,27 +635,6 @@ short sys_fsys_get_cwd(char * path, short size) {
 }
 
 /*
- * Load a file into memory at the designated destination address.
- *
- * If destination = 0, the file must be in a recognized binary format
- * that specifies its own loading address.
- *
- * Inputs:
- * path = the path to the file to load
- * destination = the destination address (0 for use file's address)
- * start = pointer to the long variable to fill with the starting address
- *         (0 if not an executable, any other number if file is executable
- *         with a known starting address)
- *
- * Returns:
- * 0 on success, negative number on error
- */
-short sys_fsys_load(const char * path, long destination, long * start) {
-    t_syscall_params params = {.arg1 = (int32_t) path, .arg2 = destination, .arg3 = (int32_t) start};
-    return syscall(KFN_LOAD, &params);
-}
-
-/*
  * Register a file loading routine
  *
  * A file loader, takes a channel number to load from and returns a
@@ -611,6 +650,99 @@ short sys_fsys_load(const char * path, long destination, long * start) {
 short sys_fsys_register_loader(const char * extension, p_file_loader loader) {
     t_syscall_params params = {.arg1 = (int32_t) extension, .arg2 = (int32_t) loader};
     return syscall(KFN_LOAD_REGISTER, &params);
+}
+
+
+/* 
+ * Process and memory calls
+ */
+
+/*
+ * Load and run an executable binary file
+ *
+ * Inputs:
+ *  path = pointer to path to the file to run
+ *  argc = number of arguments to pass to the executable
+ *  argv = array of strings containing the parameters
+ *
+ * Returns:
+ *  Any value is an error (don't expect any return on susses)
+ */
+short sys_proc_run( const char *path, int argc, char *argv[]) {
+    t_syscall_params params = {.arg1 = (int32_t)path, .arg2 = argc, (int32_t)argv};
+    return syscall(KFN_PROC_RUN, &params);
+}
+
+/*
+ * Get the upper limit of accessible RAM
+ *
+ * Inputs:
+ *  none
+ *
+ * Returns:
+ *  Address of first byte of non-accessible RAM area
+ */
+unsigned long sys_mem_get_ramtop() {
+    t_syscall_params params = {0};
+    return syscall(KFN_MEM_GET_RAMTOP, &params);
+}
+
+/*
+ * Get the upper limit of accessible RAM
+ *
+ * Inputs:
+ *  none
+ *
+ * Returns:
+ *  Address of first byte of RAM block
+ */
+unsigned long sys_mem_reserve( unsigned long size ) {
+    t_syscall_params params = {.arg1 = (uint32_t)size};
+    return syscall(KFN_MEM_RESERVE, &params);  
+}
+
+/*
+ * Raise the privilege level of this program/process to the highest level
+ *
+ * Inputs:
+ *  none (single tasking operating system)
+ *
+ * Returns:
+ *  none
+ */
+void sys_proc_elevate() {
+    t_syscall_params params = {0};
+    return syscall(KFN_PROC_ELEVATE, &params);   
+}
+
+/*
+ * Set the value of a system variable
+ *
+ * Inputs:
+ *  name = name of the system variable (pointer to string)
+ *  value = value of the system variable (pointer to string)
+ *
+ * Returns:
+ *  0 on success, any other number on error
+ */
+extern short sys_var_set( const char *name, const char *value ) {
+    t_syscall_params params = {.arg1 = (uint32_t)name, .arg2= (uint_32t)value};
+    return syscall(KFN_VAR_SET, &params);      
+}
+
+/*
+ * Get the value of a system variable
+ *
+ * Inputs:
+ *  name = name of the system variable (pointer to string)
+ *
+ * Returns:
+ *  pointer to string as value of the system variable
+ *  0 if name of variable was not found
+ */
+const char *sys_var_get( const char *name ) {
+    t_syscall_params params = {.arg1 = (uint32_t)name};
+    return syscall(KFN_VAR_GET, &params);    
 }
 
 /*
@@ -638,7 +770,7 @@ long sys_time_jiffies() {
  * Inputs:
  * time = pointer to a t_time record containing the correct time
  */
-void sys_rtc_set_time(p_time time) {
+void sys_time_setrtc(p_time time) {
     t_syscall_params params = {.arg1 = (int32_t) time};
     syscall(KFN_TIME_SETRTC, &params);
 }
@@ -649,7 +781,7 @@ void sys_rtc_set_time(p_time time) {
  * Inputs:
  * time = pointer to a t_time record in which to put the current time
  */
-void sys_rtc_get_time(p_time time) {
+void sys_time_getrtc(p_time time) {
     t_syscall_params params = {.arg1 = (int32_t) time};
     syscall(KFN_TIME_GETRTC, &params);
 }
@@ -660,14 +792,6 @@ void sys_rtc_get_time(p_time time) {
 unsigned short sys_kbd_scancode() {
     t_syscall_params params = {0};
     return syscall(KFN_KBD_SCANCODE, &params);
-}
-
-/*
- * Return an error message given an error number
- */
-const char * sys_err_message(short err_number) {
-    t_syscall_params params = {.arg1 = err_number};
-    return (const char *) syscall(KFN_ERR_MESSAGE, &params);
 }
 
 /*
@@ -691,7 +815,15 @@ const char * sys_err_message(short err_number) {
  * Inputs:
  * tables = pointer to the keyboard translation tables
  */
-short sys_kbd_layout(const char * tables) {
+short sys_kbd_setlayout(const char * tables) {
     t_syscall_params params = {.arg1 = (int32_t) tables};
     return syscall(KFN_KBD_LAYOUT, &params);
+}
+
+/*
+ * Return an error message given an error number
+ */
+const char * sys_err_message(short err_number) {
+    t_syscall_params params = {.arg1 = err_number};
+    return (const char *) syscall(KFN_ERR_MESSAGE, &params);
 }

--- a/src/mcp_syscalls.c
+++ b/src/mcp_syscalls.c
@@ -827,3 +827,285 @@ const char * sys_err_message(short err_number) {
     t_syscall_params params = {.arg1 = err_number};
     return (const char *) syscall(KFN_ERR_MESSAGE, &params);
 }
+
+/**
+ * Text Display calls
+ /**
+
+/*
+ * Reset a screen to its default text mode
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *
+ * Returns:
+ *  nothing
+ */
+extern void sys_txt_init_screen( short screen ) {
+    t_syscall_params params = {.arg1 = screen};
+    syscall(KFN_TXT_INIT_SCREEN, &params);    
+}
+
+/*
+ * Return a description of a screen's capabilities
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *
+ * Returns:
+ *  pointer to txt_capabilities structure (p_txt_capabilities)
+ */
+const p_txt_capabilities sys_txt_get_caps( short screen ) {
+    t_syscall_params params = {.arg1 = screen};
+    return (p_txt_capabilities) syscall(KFN_TXT_GET_CAPS, &params);    
+}
+
+/*
+ * Set the display mode of a screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  mode = desired mode (one from TXT_MODE_TEXT, TXT_MODE_BITMAP, TXT_MODE_TILE, 
+ *                          TXT_MODE_SPRITE, TXT_MODE_SLEEP)
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_mode( short screen, short mode ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = mode};
+    return syscall(KFN_TXT_SET_MODE, &params);    
+}
+
+/*
+ * Set text screen device driver to current screen geometry (resolution, border size)
+ *
+ * Inputs:
+ *  none
+ *
+ * Returns:
+ *  0 on succcess or any other number on error
+ */
+void sys_txt_setsizes() {
+    t_syscall_params params = {0};
+    syscall(KFN_TXT_SETSIZES, &params);       
+}
+
+/*
+ * Set the base display resolution of the screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  horizontal = number of horizontal pixels
+ *  vertical = number of verticl pixels
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_resolution( short screen, short horizontal, short vertical ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = horizontal, .arg3 = vertical};
+    return syscall(KFN_TXT_SET_RESOLUTION, &params);   
+}
+
+/*
+ * Set the size of the border (around the screen)
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  width = border width left and right of the screen in pixels
+ *  height = border height top and bottom of the screen in pixels
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_border( short screen, short width, short height ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = width, .arg3 = height};
+    syscall(KFN_TXT_SET_BORDER, &params);   
+}
+
+/*
+ * Set the color of the border (around the screen) with RGB components
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  red = red component of color (0-255)
+ *  green = green component of color (0-255)
+ *  blue = blue component of border (0-255)
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_border_color( short screen, unsigned byte red,
+                                unsigned byte green, unsigned byte blue ) {
+    t_syscall_params params = {.arg1 = screen,
+                                .arg2 = red, .arg3 = green, .arg4 = blue};
+    syscall(KFN_TXT_SET_BORDER_COLOR, &params);   
+}
+
+/*
+ * Set the font to be used in text mode for the screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  width = width of the characters in pixels
+ *  height = height of the characters in pixels
+ *  data = pointer to font data
+ *
+ * Returns:
+ *  0 on success, any other number means error (invalid screen, invalid font size)
+ */
+short sys_txt_set_font( short screen, short width, short heigth, 
+                                unisgend char *data ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = width, .arg3 = height,
+                                .arg4 = (uint32_t)data};
+    return syscall(KFN_TXT_SET_FONT, &params);   
+}
+
+/*
+ * Set the appearance of the text mode cursor
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  enable = hide(0) or show (any other number) cursor
+ *  rate = blink rate of the cursor (in Hz, see MCP manual for ranges)
+ *  character = ASCII code of the glyph from the screen's font as the cursor
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_cursor( short screen, short enable, short rate, char character ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = enable,
+                                .arg3 = rate, .arg4 = character};
+    return syscall(KFN_TXT_SET_CURSOR, &params);   
+}
+
+/*
+ * Set the rectangular region of the screen that will be used for printing,
+ * scrolling and filling.
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  region = pointer to t_rect structure (upper left corner, width, height)
+ *              coordinates in character cells. (0,0) is upper-left,
+ *              size 0 means fullscreen
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_region( short screen, p_rect region ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = (uint32_t)region};
+    return syscall(KFN_TXT_SET_REGION, &params);   
+}
+
+/*
+ * Set the foreground and background color for subsequent printing to the screen
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  foreground = color index for foreground color (0-15)
+ *  background = color index for background color (0-15)
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+short sys_txt_set_color( short screen, short foreground, short background ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = foreground, .arg3 = background};
+    return syscall(KFN_TXT_SET_COLOR, &params);   
+}
+
+/*
+ * Get the current foreground and background color
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  foreground = pointer to retrieve color index for foreground color (0-15)
+ *  background = pointer to retrieve color index for background color (0-15)
+ *
+ * Returns:
+ *  0 on success, any other number means error
+ */
+ short sys_txt_get_color( short screen, short *foreground, short *background ) {
+    t_syscall_params params = {.arg1 = screen,
+                                .arg2 = (uint32_t)foreground,
+                                .arg3 = (uint32_t)background};
+    return syscall(KFN_TXT_GET_COLOR, &params);   
+ }
+
+ /*
+ * Set cursor position on the screen, relative to origin of current region
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  x = relative x position (in character positions)
+ *  y = relative y position (in character positions)
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_xy( short screen, short x, short y ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = x, .arg3 = y};
+    syscall(KFN_TXT_SET_XY, &params);   
+}
+
+/*
+ * Get cursor position on the screen, relative to origin of current region
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  position = pointer to x,y structure to retrive position
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_get_xy( short screen, p_point position ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = (uint32_t)position};
+    syscall(KFN_TXT_GET_XY, &params);   
+}
+
+/*
+ * Scroll the text in the current region
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  horizontal = number of horizontal pixels to scroll
+ *  vertical = number of verticl pixels to scroll
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_scroll( short screen, short horizontal, short vertical ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = horizontal,
+                                .arg3 = vertical};
+    syscall(KFN_TXT_SCROLL, &params);   
+}
+
+/*
+ * Set visibility of the cursor
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  is_visible = hidden (FALSE or 0) or visible (any other number)
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_set_cursor_vis( short screen, short is_visible ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = is_visible};
+    syscall(KFN_TXT_SET_CURSOR_VIS, &params);   
+}
+
+/*
+ * Get screensize in total pixels (so without taking the border into consideration)
+ *
+ * Inputs:
+ *  screen = screenID of the screen
+ *  text_size = pointer to t_extent structure to retrieve size in visible characters
+ *  pixel_size = pointer to t_extent structure to retrieve size in pixels
+ *
+ * Returns:
+ *  nothing
+ */
+void sys_txt_get_sizes( short screen, p_extent text_size, p_extent pixel_size ) {
+    t_syscall_params params = {.arg1 = screen, .arg2 = (uint32_t)text_size,
+                                (uint32_t)pixel_size};
+    syscall(KFN_TXT_GET_SIZES, &params);   
+}

--- a/src/mcp_syscalls.c
+++ b/src/mcp_syscalls.c
@@ -298,10 +298,10 @@ short sys_chan_close(short chan) {
  * Returns:
  *  0 on success, any other on error
  */
-short sys_chan_swap(short channel1, short channel2) (
+short sys_chan_swap(short channel1, short channel2) {
     t_syscall_params params = {.arg1 = channel1, .arg2 = channel2};
     return syscall(KFN_CHAN_SWAP, &params);
-)
+}
 
 /* Get the device ID of the device on  a channel
  *

--- a/src/mcp_syscalls.c
+++ b/src/mcp_syscalls.c
@@ -830,7 +830,7 @@ const char * sys_err_message(short err_number) {
 
 /**
  * Text Display calls
- /**
+ **/
 
 /*
  * Reset a screen to its default text mode
@@ -934,8 +934,8 @@ void sys_txt_set_border( short screen, short width, short height ) {
  * Returns:
  *  nothing
  */
-void sys_txt_set_border_color( short screen, unsigned byte red,
-                                unsigned byte green, unsigned byte blue ) {
+void sys_txt_set_border_color( short screen, uint8_t red,
+                                uint8_t green, uint8_t blue ) {
     t_syscall_params params = {.arg1 = screen,
                                 .arg2 = red, .arg3 = green, .arg4 = blue};
     syscall(KFN_TXT_SET_BORDER_COLOR, &params);   
@@ -953,8 +953,8 @@ void sys_txt_set_border_color( short screen, unsigned byte red,
  * Returns:
  *  0 on success, any other number means error (invalid screen, invalid font size)
  */
-short sys_txt_set_font( short screen, short width, short heigth, 
-                                unisgend char *data ) {
+short sys_txt_set_font( short screen, short width, short height, 
+                                unsigned char *data ) {
     t_syscall_params params = {.arg1 = screen, .arg2 = width, .arg3 = height,
                                 .arg4 = (uint32_t)data};
     return syscall(KFN_TXT_SET_FONT, &params);   

--- a/src/mcp_syscalls.c
+++ b/src/mcp_syscalls.c
@@ -943,7 +943,7 @@ void sys_txt_set_border_color( short screen, uint8_t red,
 
 /*
  * Set the font to be used in text mode for the screen
- *
+ * 
  * Inputs:
  *  screen = screenID of the screen
  *  width = width of the characters in pixels


### PR DESCRIPTION
I have added all MCP1.0 functions (and data structures) to the Foenix target. The routines are all named very strictly conform the MCP1.0 User Manual.

Some of this I could test, some not, because the f68 emulator that I use simply doesn't support all functions (and of course because I don't have time to test ALL functions ;-). But so far, I have found no errors.

Regards, keep it up!
René Kint
