### PR TITLE
Fix broken argc/argv on MCP

### DIFF
--- a/src/startup-user.s
+++ b/src/startup-user.s
@@ -34,6 +34,8 @@
               .align  2
 __program_root_section:
 __program_start:
+              move.l d1,d6 ;; Save argc from MCP
+              move.l a1,a6 ;; Save argv from MCP              
               move.l  #.sectionEnd stack + 1,sp
 #ifdef __CALYPSI_DATA_MODEL_SMALL__
               lea.l   _NearBaseAddress.l,a4
@@ -67,6 +69,7 @@ __call_heap_initialize:
               call    __heap_initialize
 
               .section libcode, root, noreorder
-              movem.l (4,sp),d0/a0
+              move.l d6,d0 ;; Load argc from MCP
+              move.l a6,a0 ;; Load argv from MCP
               call    main
               jump    exit


### PR DESCRIPTION
## Fix
Command line arguments are broken in MCP with argc is returning a garbage values. The previous solution tried copying values from the OS stack onto the C stack, but the data is corrupted. I am using the alternative method, and obtaining  the values from d1/a1 to fix the issue.

## Reference
From page 49 in the MCP manual:
The kernel follows the general C convention of passing two
arguments: argc and argv, where argc is an int count of arguments, and argv is an array of
character pointers containing the actual parameters.
The kernel will then call the user program (with JSR) while dropping out of supervisor mode.
NOTE: while argc and argv, will be on the user stack, they are also available in D1 and A1,
respectively.
Upon completion, the user program should quit by calling the system call sys_exit. This
will ensure that the command line utility can restart correctly.

## Testing
I tested locally by copying the startup-user.s file to my project and renaming the ".rtmodel cstartup" from "Foenix_user" to "Foenix_test" and passing the "--cstartup Foenix_test" argument to ln68k.